### PR TITLE
added exhaustiveUtterances option

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,9 @@ alexa.app = function(name,endpoint) {
 	
 	// Persist session variables from every request into every response?
 	this.persistentSession = true;
+
+	// use the minimal set of utterances or the full cartesian product?
+	this.exhaustiveUtterances = false;
 	
 	// A catch-all error handler - do nothing by default
 	this.error = null;
@@ -337,9 +340,73 @@ function expandShortcuts(str,slots,dictionary) {
   return [str];
 }
 
+var slotIndexes = [];
+function expandSlotValues (variations, slotSampleValues) {
+  var i;
+
+  var slot;
+  for (slot in slotSampleValues) {
+
+    var sampleValues = slotSampleValues[slot];
+
+    var idx = -1;
+    if (typeof slotIndexes[slot] !== "undefined") {
+      idx = slotIndexes[slot];
+    }
+
+    var newVariations = [];
+
+    // make sure we have enough variations that we can get through the sample values
+    // at least once for each alexa-app utterance...  this isn't strictly as 
+    // minimalistic as it could be.
+    //
+    // our *real* objective is to make sure that each sampleValue gets used once per
+    // intent, but each intent spans multiple utterances; it would require heavy
+    // restructuring of the way the utterances are constructed to keep track of
+    // whether every slot was given each sample value once within an Intent's set 
+    // of utterances.  So we take the easier route, which generates more utterances
+    // in the output (but still many less than we would get if we did the full 
+    // cartesian product). 
+    if (variations.length < sampleValues.length) {
+      var mod = variations.length;
+      var xtraidx = 0;
+      while (variations.length < sampleValues.length) {
+        variations.push (variations[xtraidx]);
+        xtraidx = (xtraidx + 1) % mod;
+      }
+    }
+
+    variations.forEach (function (variation, j) {
+      var newVariation = [];
+      //var logmsg = "[ ";
+      variation.forEach (function (value, k) {
+        if (value == "slot-" + slot) {
+          idx = (idx + 1) % sampleValues.length;
+          slotIndexes[slot] = idx;
+
+          //logmsg += "<" + value + " --> " + sampleValues[idx] + "> ";
+          value = sampleValues[idx];
+        }
+        else {
+          //logmsg += "<" + value + "> ";
+        }
+
+        newVariation.push (value);
+      });
+      //logmsg += "]";
+      //console.log (logmsg);
+      newVariations.push (newVariation);
+    });
+
+    variations = newVariations;
+  }
+
+  return variations;
+}
+
 // Generate a list of utterances from a template
-function generateUtterances(str,slots,dictionary) {
-  var placeholders=[], utterances=[], slotmap={};
+function generateUtterances(str,slots,dictionary,exhaustiveUtterances) {
+  var placeholders=[], utterances=[], slotmap={}, slotValues=[];
   // First extract sample placeholders values from the string
   str = str.replace(/\{([^\}]+)\}/g, function(match,p1) {
     var expandedValues=[], slot, values = p1.split("|");
@@ -353,12 +420,31 @@ function generateUtterances(str,slots,dictionary) {
     if (slot) {
       slotmap[slot] = placeholders.length;
     }
-    placeholders.push( expandedValues );
+
+    // if we're dealing with minimal utterances, we will delay the expansion of the
+    // values for the slots; all the non-slot expansions need to be fully expanded
+    // in the cartesian product
+    if (!exhaustiveUtterances && slot)
+    {
+      placeholders.push( [ "slot-" + slot ] );
+      slotValues[slot] = expandedValues;
+    }
+    else
+    {
+      placeholders.push( expandedValues );
+    }
+
     return "{"+(slot || placeholders.length-1)+"}";
   });
   // Generate all possible combinations using the cartesian product
   if (placeholders.length>0) {
     var variations = Combinatorics.cartesianProduct.apply(Combinatorics,placeholders).toArray();
+
+    if (!exhaustiveUtterances)
+    {
+      variations = expandSlotValues (variations, slotValues);
+    }
+
     // Substitute each combination back into the original string
     variations.forEach(function(values) {
       // Replace numeric placeholders

--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ alexa.app = function(name,endpoint) {
 			intent = self.intents[intentName];
 			if (intent.schema && intent.schema.utterances) {
 				intent.schema.utterances.forEach(function(sample) {
-					var list = generateUtterances(sample,intent.schema.slots,self.dictionary);
+					var list = generateUtterances(sample,intent.schema.slots,self.dictionary,self.exhaustiveUtterances);
 					list.forEach(function(utterance) {
 						out+=intent.name+"\t"+(utterance.replace(/\s+/g,' '))+"\n";
 					});


### PR DESCRIPTION
I love alexa-app's ability to generate utterances.  It has helped me build very large lists of utterances that would be impossible to manage by hand.

I have run into limitations, though, when I have utterances with a number of shortcuts plus a number of slots with their own dictionaries.  The cartesian product gets so large that I can't post all the utterances in my Alexa Skill's interaction model.

Some of this stuff is not well documented, but I have been doing a lot of reading, and other developers have indicated that you don't need to include every sample value in every variant of the utterance.  So we don't need a strict cartesian product.

I have added a configuration option that lets you control whether a full cartesian product is generated.  The default is to *not* generate the full cartesian product.  It generates the full cartesian product of the *shortcuts*, and then fills in sample values for the slots.

Let's look at a quick example.

```
app.dictionary = {
    "movie_names": ["star wars", "inception", "gattaca", "the matrix"]
};

app.intent('DemoIntent',
    {
        "slots": {
            "MOVIE":"LITERAL"
        },
        "utterances": [
            "{foo|bar|baz} {foo|bar|baz} {movie_names|MOVIE}"
        ]
    },
    function (request, response) {
    }
);
```

Here are the default utterances generated by my modified code:


```
DemoIntent	foo foo {star wars|MOVIE}
DemoIntent	bar foo {inception|MOVIE}
DemoIntent	baz foo {gattaca|MOVIE}
DemoIntent	foo bar {the matrix|MOVIE}
DemoIntent	bar bar {star wars|MOVIE}
DemoIntent	baz bar {inception|MOVIE}
DemoIntent	foo baz {gattaca|MOVIE}
DemoIntent	bar baz {the matrix|MOVIE}
DemoIntent	baz baz {star wars|MOVIE}
```

Note that every combination of the two shortcuts are generated (3 * 3 = 9).  Then the four sample movie titles are filled in.  Each movie title appears at least once, which should be sufficient for good recognition.

Compare this to the full cartesian product, which is 36 (3 * 3 * 4) utterances.  This is 4x larger than the default.  For this example, it's not a big deal, but the problem explodes when you have larger dictionaries and more slots.

```
DemoIntent	foo foo {star wars|MOVIE}
DemoIntent	bar foo {star wars|MOVIE}
DemoIntent	baz foo {star wars|MOVIE}
DemoIntent	foo bar {star wars|MOVIE}
DemoIntent	bar bar {star wars|MOVIE}
DemoIntent	baz bar {star wars|MOVIE}
DemoIntent	foo baz {star wars|MOVIE}
DemoIntent	bar baz {star wars|MOVIE}
DemoIntent	baz baz {star wars|MOVIE}
DemoIntent	foo foo {inception|MOVIE}
DemoIntent	bar foo {inception|MOVIE}
DemoIntent	baz foo {inception|MOVIE}
DemoIntent	foo bar {inception|MOVIE}
DemoIntent	bar bar {inception|MOVIE}
DemoIntent	baz bar {inception|MOVIE}
DemoIntent	foo baz {inception|MOVIE}
DemoIntent	bar baz {inception|MOVIE}
DemoIntent	baz baz {inception|MOVIE}
DemoIntent	foo foo {gattaca|MOVIE}
DemoIntent	bar foo {gattaca|MOVIE}
DemoIntent	baz foo {gattaca|MOVIE}
DemoIntent	foo bar {gattaca|MOVIE}
DemoIntent	bar bar {gattaca|MOVIE}
DemoIntent	baz bar {gattaca|MOVIE}
DemoIntent	foo baz {gattaca|MOVIE}
DemoIntent	bar baz {gattaca|MOVIE}
DemoIntent	baz baz {gattaca|MOVIE}
DemoIntent	foo foo {the matrix|MOVIE}
DemoIntent	bar foo {the matrix|MOVIE}
DemoIntent	baz foo {the matrix|MOVIE}
DemoIntent	foo bar {the matrix|MOVIE}
DemoIntent	bar bar {the matrix|MOVIE}
DemoIntent	baz bar {the matrix|MOVIE}
DemoIntent	foo baz {the matrix|MOVIE}
DemoIntent	bar baz {the matrix|MOVIE}
DemoIntent	baz baz {the matrix|MOVIE}
```

In my current app, I have dictionaries with 30+ values in them.  Combine that with 2 or 3 shortcuts in an utterance, 8 utterances per intent, and very quickly, I exceed the 250KB sample utterances limit at Amazon.  In fact, my utterances were more than 20MB!  Using the minimalistic technique resulted in about 40KB.  This would let me use many more values in my dictionaries, which might help me tune the recognition a little better.

BTW -- the code is designed that for each defined utterance in the Intent, it will ensure that there are enough generated utterances so that every value from every dictionary can be used at least once.  Technically, I think we only need to make sure that the dictionary values for a given slot are used once per *Intent*, not once per alexa-app defined utterance.  So I'm being a little wasteful here, but it kept my code changes to a minimum.

My code isn't quite as elegant as yours; there may be better ways to accomplish what I'm trying to do.  Feel free to reject the pull request if there's a better/cleaner way to do this.  But I believe this is a real need when you start dealing with real-world data where you need lots of sample inputs.