### PR TITLE
Upgrade Clear/Reprompt/Say methods to SSML

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,23 +15,23 @@ alexa.response = function() {
 	};
 	this.say = function(str) {
 		if (typeof this.response.response.outputSpeech=="undefined") {
-			this.response.response.outputSpeech = {"type":"PlainText","text":str};
+			this.response.response.outputSpeech = {"type":"SSMS","ssms": "<speak>" + str + "</speak>" };
 		}
 		else {
-			this.response.response.outputSpeech.text+=str;
+			this.response.response.outputSpeech.ssms = this.response.response.outputSpeech.ssms.replace("</speak>", str + "</speak>");
 		}
 		return this;
 	};
 	this.clear = function(str) {
-		this.response.response.outputSpeech = {"type":"PlainText","text":""};
+		this.response.response.outputSpeech = {"type":"SSMS","ssms":""};
 		return this;
 	};
 	this.reprompt = function(str) {
 		if (typeof this.response.response.reprompt=="undefined") {
-			this.response.response.reprompt = {"outputSpeech" : {"type":"PlainText","text":str}};
+			this.response.response.reprompt = {"outputSpeech" : {"type":"SSMS","ssms": "<speak>" + str + "</speak>" }};
 		}
 		else {
-			this.response.response.reprompt.outputSpeech.text+=str;
+			this.response.response.reprompt.ssms = this.response.response.reprompt.ssms.replace("</speak>", str + "</speak>");
 		}
 		return this;
 	};

--- a/index.js
+++ b/index.js
@@ -15,23 +15,23 @@ alexa.response = function() {
 	};
 	this.say = function(str) {
 		if (typeof this.response.response.outputSpeech=="undefined") {
-			this.response.response.outputSpeech = {"type":"SSMS","ssms": "<speak>" + str + "</speak>" };
+			this.response.response.outputSpeech = {"type":"SSML","ssml": "<speak>" + str + "</speak>" };
 		}
 		else {
-			this.response.response.outputSpeech.ssms = this.response.response.outputSpeech.ssms.replace("</speak>", str + "</speak>");
+			this.response.response.outputSpeech.ssml = this.response.response.outputSpeech.ssml.replace("</speak>", str + "</speak>");
 		}
 		return this;
 	};
 	this.clear = function(str) {
-		this.response.response.outputSpeech = {"type":"SSMS","ssms":""};
+		this.response.response.outputSpeech = {"type":"SSML","ssml":""};
 		return this;
 	};
 	this.reprompt = function(str) {
 		if (typeof this.response.response.reprompt=="undefined") {
-			this.response.response.reprompt = {"outputSpeech" : {"type":"SSMS","ssms": "<speak>" + str + "</speak>" }};
+			this.response.response.reprompt = {"outputSpeech" : {"type":"SSML","ssml": "<speak>" + str + "</speak>" }};
 		}
 		else {
-			this.response.response.reprompt.ssms = this.response.response.reprompt.ssms.replace("</speak>", str + "</speak>");
+			this.response.response.reprompt.ssml = this.response.response.reprompt.ssml.replace("</speak>", str + "</speak>");
 		}
 		return this;
 	};


### PR DESCRIPTION
Amazon just updated to their new SSML feature for speech output. Since I was playing with that new feature I thought I would update your API to use this. The `response.clear/reprompt/say` now get wrapped in the new `<speak></speak>` tags and the new speech type is applied.

I have been testing and playing with this all night (you can see my test project [here](https://github.com/tvand7093/Alexa-node)) and it seems to work! I don't really have time to try and update the README or anything, but hopefully this code change is useful for others. 