### PR TITLE
adding support for SSML in responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird');
 var AlexaUtterances = require('alexa-utterances');
+var SSML = require('./to-ssml');
 
 var alexa={};
 
@@ -14,10 +15,11 @@ alexa.response = function() {
 	};
 	this.say = function(str) {
 		if (typeof this.response.response.outputSpeech=="undefined") {
-			this.response.response.outputSpeech = {"type":"PlainText","text":str};
+			this.response.response.outputSpeech = {"type":"SSML","ssml":SSML.fromStr(str)};
 		}
 		else {
-			this.response.response.outputSpeech.text+=str;
+			// append str to the current outputSpeech, stripping the out speak tag
+			this.response.response.outputSpeech.ssml = SSML.fromStr(str, this.response.response.outputSpeech.ssml);
 		}
 		return this;
 	};
@@ -27,15 +29,17 @@ alexa.response = function() {
 	};
 	this.reprompt = function(str) {
 		if (typeof this.response.response.reprompt=="undefined") {
-			this.response.response.reprompt = {"outputSpeech" : {"type":"PlainText","text":str}};
+			this.response.response.reprompt = {"outputSpeech" : {"type":"SSML","ssml":SSML.fromStr(str)}};
 		}
 		else {
-			this.response.response.reprompt.outputSpeech.text+=str;
+			// append str to the current outputSpeech, stripping the out speak tag
+			this.response.response.reprompt.outputSpeech.ssml = SSML.fromStr(str, this.response.response.reprompt.outputSpeech.text);
 		}
 		return this;
 	};
 	this.card = function(title,content,subtitle) {
-		this.response.response.card = {"type":"Simple","content":content,"title":title,"subtitle":subtitle};
+		// remove all SSML to keep the card clean
+		this.response.response.card = {"type":"Simple","title":title,"content":SSML.cleanse(content),"subtitle":subtitle};
 		return this;
 	};
 	this.shouldEndSession = function(bool,reprompt) {

--- a/to-ssml.js
+++ b/to-ssml.js
@@ -1,0 +1,43 @@
+/**
+ Copyright 2015 Rick Wargo. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+ http://aws.amazon.com/apache2.0/
+
+ or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+var Numbered = require('numbered');
+
+'use strict';
+
+// Util functions for generating valid SSML from plain text
+// ========================================================
+
+var ssml = (function () {
+    return {
+        fromStr: function (str, current_ssml) {
+            if (current_ssml) {
+                current_ssml = current_ssml.replace(/<speak>/gi, ' ').replace(/<\/speak>/gi, ' ').trim()
+            } else {
+                current_ssml = '';
+            }
+            if (str.match(/[0-9]/)) {
+                str = str.replace(/[0-9]+(.[0-9])?(?![^<]+>)/g, function (num) {
+                    return Numbered.stringify(num).replace(/-/g, ' ');
+                });
+            }
+            //TODO: Need a library with how to easily construct these statements with appropriate spacing, etc.
+            //TODO: make sure all attribute values are surrounded by "..."
+            var ssml_str = '<speak>' + current_ssml + (current_ssml === '' ? '' : ' ') + str + '</speak>';
+            return ssml_str.replace(/  +/, ' ');
+        },
+        cleanse: function(str) {
+            return str.replace(/<\/?(speak|break|phoneme|say-as|p\b|s\b|w\b)[^>]*>/gi, ' ').replace(/  +/, ' ');
+        }
+    }
+})();
+
+module.change_code = 1;
+module.exports = ssml;


### PR DESCRIPTION
I have added initial support for making SSML responses, converting each plain_text response to SSML. There is utility associated such that it knows to remove the SSML in a card, and can handle linking of speechOutputs such that there is only one outer <speak /> element.

This allows you to embed SSML in your response.say() calls and makes it easy to use that text in the response.card() call as it will strip out only the SSML.

I left .clear() alone as having an empty response in PLAIN_TEXT should not break anything. The first assigment will change it to SSML.

NOTE: One of the other things SSML.fromStr provides is a mapping of number literals to word phrases through the numbered module. Even though Alexa speaks the number literals, if it is at the end of the sentence, it will also say "dot" after reading the number. I believe the API states that the word should be used instead of the literal.