### PR TITLE
remove support for card subtitle

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ alexa.response = function() {
 		}
 		return this;
 	};
-	this.card = function(title,content,subtitle) {
-		this.response.response.card = {"type":"Simple","content":content,"title":title,"subtitle":subtitle};
+	this.card = function(title,content) {
+		this.response.response.card = {"type":"Simple","content":content,"title":title};
 		return this;
 	};
 	this.shouldEndSession = function(bool,reprompt) {


### PR DESCRIPTION
subtitle is not listed in the api documentation - i removed it to avoid any confusion. When I first used your library I added subtitle to all my cards (not having read the API docs clearly) and the cards did not come out as expected. I had to rework all my cards based on this understanding of subtitle.