### PR TITLE
support for custom slots

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,7 @@ alexa.app = function(name,endpoint) {
 		}
 		if (enableDebug) {
 			express.get(endpoint,function(req,res) {
-				res.render('test',{"json":self,"schema":self.schema(),"utterances":self.utterances(),self.customSlotTypes()});
+				res.render('test',{"json":self,"schema":self.schema(),"utterances":self.utterances(),"slot_types":self.customSlotTypes()});
 			});
 		}
 	};

--- a/index.js
+++ b/index.js
@@ -256,7 +256,26 @@ alexa.app = function(name,endpoint) {
 		};
 		return JSON.stringify(schema,null,3);
 	};
-	
+
+	// Generate the Custom Slot Types for the Interaction Model
+	this.customSlotTypes = function () {
+			var intentName, slotTypes = [], intent, out = "";
+			for (intentName in self.intents) {
+					intent = self.intents[intentName];
+					if (intent.schema && intent.schema.slot_types) {
+							intent.schema.slot_types.forEach(function (slot_type) {
+									out += slot_type.name + "\n";
+									out += slot_type.name.replace(/./g, '-') + "\n";
+									slot_type.values.forEach(function (value) {
+											out += value + "\n";
+									});
+									out += "\n";
+							});
+					}
+			};
+			return out;
+	};
+
 	// Generate a list of sample utterances
 	this.utterances = function() {
 		var intentName, utterances=[], intent, out="";
@@ -300,7 +319,7 @@ alexa.app = function(name,endpoint) {
 		}
 		if (enableDebug) {
 			express.get(endpoint,function(req,res) {
-				res.render('test',{"json":self,"schema":self.schema(),"utterances":self.utterances()});
+				res.render('test',{"json":self,"schema":self.schema(),"utterances":self.utterances(),self.customSlotTypes()});
 			});
 		}
 	};


### PR DESCRIPTION
Added support for custom slots. This addresses issue #25. It also helps with my code :). 

Slots, Slot Types, and values are added to the schema for each .intent() call. Below is a usage example.

        "slots": {
            "Level": "LIST_OF_LEVELS"
        },
        "slot_types": [
            {
                "name":"Level",
                "values":["beginner","easy","normal","medium","average","standard","advanced","challenging","hard","difficult"]
            }
        ]

When the Alexa Tester web page is refreshed, it will list all the custom slot types in its own section, easing the effort of entering in the info in the interaction model. One outstanding issue is if there are multiple instances of the same slot type, they will each get their own output in the window. Also the slot_type needs to be output, too for easier copy/paste.

An example of the output is below.

    Level
    -----
    beginner
    easy
    normal
    medium
    average
    standard
    advanced
    challenging
    hard
    difficult

There is an update needed to alexa-app-server to view the custom slot type values near the bottom of the testing web page. I'll submit a pull request for that, too.