### PR TITLE
Add: Support for Retrieving Alexa Account Linking accessToken

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ alexa.request = function(json) {
 		"new":this.data.session.new,
 		"sessionId":this.data.session.sessionId,
 		"userId":this.data.session.user.userId,
+    		"accessToken":this.data.session.user.accessToken || null,
 		"attributes":this.data.session.attributes,
 		"application":this.data.session.application
 	};


### PR DESCRIPTION
It's more convenient (and cleaner) to retrieve the accessToken from
`request.sessionDetails.accessToken` rather than `request.data.session.user.accessToken`.

I thought about conditionally including the `accessToken` property, but purposefully setting it to `null` defines a clear contract and leaves no ambiguity.

If you're unfamiliar with Alexa account linking, see https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/linking-an-alexa-user-with-a-user-in-your-system