### PR TITLE
added missing numbered module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "alexa-utterances": "^0.1.0",
-    "bluebird": "^2.10.2"
+    "bluebird": "^2.10.2",
+    "numbered": "^1.0.0"
   }
 }


### PR DESCRIPTION
@matt-kruse alexa-app@2.3.0 uses the `numbered` module, but it's not specified in the package.json file. This fixes it. Should publish a new version to npm asap because the current version is totes busted. :-/