### PR TITLE
Add state to callback functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ alexa.app = function(name, endpoint) {
   this.sessionEnded = function(func) {
     self.sessionEndedFunc = func;
   };
-  this.request = function(request_json) {
+  this.request = function(request_json, state) {
     return new Promise(function(resolve, reject) {
       var request = new alexa.request(request_json);
       var response = new alexa.response();
@@ -266,7 +266,7 @@ alexa.app = function(name, endpoint) {
           if ("IntentRequest" === requestType) {
             var intent = request_json.request.intent.name;
             if (typeof self.intents[intent] != "undefined" && typeof self.intents[intent]["function"] == "function") {
-              if (false !== self.intents[intent]["function"](request, response)) {
+              if (false !== self.intents[intent]["function"](request, response, state)) {
                 response.send();
               }
             } else {
@@ -274,7 +274,7 @@ alexa.app = function(name, endpoint) {
             }
           } else if ("LaunchRequest" === requestType) {
             if (typeof self.launchFunc == "function") {
-              if (false !== self.launchFunc(request, response)) {
+              if (false !== self.launchFunc(request, response, state)) {
                 response.send();
               }
             } else {
@@ -282,7 +282,7 @@ alexa.app = function(name, endpoint) {
             }
           } else if ("SessionEndedRequest" === requestType) {
             if (typeof self.sessionEndedFunc == "function") {
-              if (false !== self.sessionEndedFunc(request, response)) {
+              if (false !== self.sessionEndedFunc(request, response, state)) {
                 response.send();
               }
             }


### PR DESCRIPTION
I am using this package to write [node-red bindings for alexa](https://github.com/mattotodd/node-red-contrib-alexa).  

The issue is that the way that [node-red](http://nodered.org/) processes messages,  it can not respond to a http request until the end of a chain of nodes, and then it uses the express response object to respond.

These nodes do not know about one another, they only pass a message (javascript object) down the chain, and the express response object needs to be passed down that chain.

HTTP In --->  Do Some Processing --> Add Alexa Say Command --> HTTP Out

The way the library was currently written, I couldn't find a way to pass along the express response object.
So for now I'm including it it my package with the changes, but I'd rather include `alexa-app` as a dependency 

The usage within my project can be found [here](https://github.com/mattotodd/node-red-contrib-alexa/blob/master/alexa.js#L81)