### PR TITLE
resolves issue #75: response.clear() resets to SSML instead of PlainText

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ alexa.response = function() {
   };
   this.clear = function(/*str*/) {
     this.response.response.outputSpeech = {
-      "type": "PlainText",
-      "text": ""
+      "type": "SSML",
+      "ssml": SSML.fromStr("")
     };
     return this;
   };

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -111,8 +111,8 @@ describe("Alexa", function() {
                   return response.response.outputSpeech;
                 });
                 return expect(subject).to.eventually.become({
-                  text: "",
-                  type: "PlainText"
+                  ssml: "<speak></speak>",
+                  type: "SSML"
                 });
               });
               it("clears output when clear is called and say is then called", function() {
@@ -128,11 +128,9 @@ describe("Alexa", function() {
                 subject = subject.then(function(response) {
                   return response.response.outputSpeech;
                 });
-                //this seems like a strange result - should type be ssml? looks like a bug
                 return expect(subject).to.eventually.become({
                   ssml: "<speak>tubular!</speak>",
-                  text: "",
-                  type: "PlainText"
+                  type: "SSML"
                 });
               });
 


### PR DESCRIPTION
response.clear() sets the default outputSpeech to SSML, staying consistent with .say() always using SSML, and updates tests to follow this behavior.
