### PR TITLE
AudioPlayer functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Temporary Items
 
 #IDE
 .idea
+.vscode

--- a/index.js
+++ b/index.js
@@ -4,488 +4,489 @@ var SSML = require("./to-ssml");
 var alexa = {};
 
 alexa.response = function () {
-  var self = this;
-  this.resolved = false;
-  this.response = {
-    "version": "1.0",
-    "sessionAttributes": {},
-    "response": {
-      "directives": [],
-      "shouldEndSession": true
-    }
-  };
-  this.say = function (str) {
-    if (typeof this.response.response.outputSpeech == "undefined") {
-      this.response.response.outputSpeech = {
-        "type": "SSML",
-        "ssml": SSML.fromStr(str)
-      };
-    } else {
-      // append str to the current outputSpeech, stripping the out speak tag
-      this.response.response.outputSpeech.ssml = SSML.fromStr(str, this.response.response.outputSpeech.ssml);
-    }
-    return this;
-  };
-  this.clear = function (/*str*/) {
-    this.response.response.outputSpeech = {
-      "type": "PlainText",
-      "text": ""
-    };
-    return this;
-  };
-  this.reprompt = function (str) {
-    if (typeof this.response.response.reprompt == "undefined") {
-      this.response.response.reprompt = {
-        "outputSpeech": {
-          "type": "SSML",
-          "ssml": SSML.fromStr(str)
-        }
-      };
-    } else {
-      // append str to the current outputSpeech, stripping the out speak tag
-      this.response.response.reprompt.outputSpeech.ssml = SSML.fromStr(str, this.response.response.reprompt.outputSpeech.text);
-    }
-    return this;
-  };
-  this.card = function (oCard) {
-    if (2 == arguments.length) {  //backwards compat
-      oCard = {
-        type: "Simple",
-        title: arguments[0],
-        content: arguments[1]
-      };
-    }
+	var self = this;
+	this.resolved = false;
+	this.response = {
+		"version": "1.0",
+		"sessionAttributes": {},
+		"response": {
+			"directives": [],
+			"shouldEndSession": true
+		}
+	};
+	this.say = function (str) {
+		if (typeof this.response.response.outputSpeech == "undefined") {
+			this.response.response.outputSpeech = {
+				"type": "SSML",
+				"ssml": SSML.fromStr(str)
+			};
+		} else {
+			// append str to the current outputSpeech, stripping the out speak tag
+			this.response.response.outputSpeech.ssml = SSML.fromStr(str, this.response.response.outputSpeech.ssml);
+		}
+		return this;
+	};
+	this.clear = function (/*str*/) {
+		this.response.response.outputSpeech = {
+			"type": "PlainText",
+			"text": ""
+		};
+		return this;
+	};
+	this.reprompt = function (str) {
+		if (typeof this.response.response.reprompt == "undefined") {
+			this.response.response.reprompt = {
+				"outputSpeech": {
+					"type": "SSML",
+					"ssml": SSML.fromStr(str)
+				}
+			};
+		} else {
+			// append str to the current outputSpeech, stripping the out speak tag
+			this.response.response.reprompt.outputSpeech.ssml = SSML.fromStr(str, this.response.response.reprompt.outputSpeech.text);
+		}
+		return this;
+	};
+	this.card = function (oCard) {
+		if (2 == arguments.length) {  //backwards compat
+			oCard = {
+				type: "Simple",
+				title: arguments[0],
+				content: arguments[1]
+			};
+		}
 
-    var requiredAttrs = [],
-      clenseAttrs = [];
+		var requiredAttrs = [],
+			clenseAttrs = [];
 
-    switch (oCard.type) {
-      case 'Simple':
-        requiredAttrs.push('content');
-        clenseAttrs.push('content');
-        break;
-      case 'Standard':
-        requiredAttrs.push('text');
-        clenseAttrs.push('text');
-        if (('image' in oCard) && (!('smallImageUrl' in oCard['image']) && !('largeImageUrl' in oCard['image']))) {
-          console.error('If card.image is defined, must specify at least smallImageUrl or largeImageUrl');
-          return this;
-        }
-        break;
-      default:
-        break;
-    }
+		switch (oCard.type) {
+			case 'Simple':
+				requiredAttrs.push('content');
+				clenseAttrs.push('content');
+				break;
+			case 'Standard':
+				requiredAttrs.push('text');
+				clenseAttrs.push('text');
+				if (('image' in oCard) && (!('smallImageUrl' in oCard['image']) && !('largeImageUrl' in oCard['image']))) {
+					console.error('If card.image is defined, must specify at least smallImageUrl or largeImageUrl');
+					return this;
+				}
+				break;
+			default:
+				break;
+		}
 
-    var hasAllReq = requiredAttrs.every(function (idx) {
-      if (!(idx in oCard)) {
-        console.error('Card object is missing required attr "' + idx + '"');
-        return false;
-      }
-      return true;
-    });
+		var hasAllReq = requiredAttrs.every(function (idx) {
+			if (!(idx in oCard)) {
+				console.error('Card object is missing required attr "' + idx + '"');
+				return false;
+			}
+			return true;
+		});
 
-    if (!hasAllReq) {
-      return this;
-    }
+		if (!hasAllReq) {
+			return this;
+		}
 
-    // remove all SSML to keep the card clean
-    clenseAttrs.forEach(function (idx) {
-      oCard[idx] = SSML.cleanse(oCard[idx]);
-    });
+		// remove all SSML to keep the card clean
+		clenseAttrs.forEach(function (idx) {
+			oCard[idx] = SSML.cleanse(oCard[idx]);
+		});
 
-    this.response.response.card = oCard;
+		this.response.response.card = oCard;
 
-    return this;
-  };
-  this.linkAccount = function () {
-    this.response.response.card = {
-      "type": "LinkAccount"
-    };
-    return this;
-  };
-  this.shouldEndSession = function (bool, reprompt) {
-    this.response.response.shouldEndSession = bool;
-    if (reprompt) {
-      this.reprompt(reprompt);
-    }
-    return this;
-  };
-  this.session = function (key, val) {
-    if (typeof val == "undefined") {
-      return this.response.sessionAttributes[key];
-    } else {
-      this.response.sessionAttributes[key] = val;
-    }
-    return this;
-  };
-  this.clearSession = function (key) {
-    if (typeof key == "string" && typeof this.response.sessionAttributes[key] != "undefined") {
-      delete this.response.sessionAttributes[key];
-    } else {
-      this.response.sessionAttributes = {};
-    }
-    return this;
-  };
-  this.audioPlayer = {
-    play: function (url, token, playBehavior, expectedPreviousToken, offsetInMilliseconds) {
-      if (2 == arguments.length) {
-        audioPlayerDirective = {
-          "type": "AudioPlayer.Play",
-          "playBehavior": "REPLACE_ALL",
-          "audioItem": {
-            "stream": {
-              "url": url,
-              "token": token,
-              "expectedPreviousToken": "no previous token",
-              "offsetInMilliseconds": 0
-            }
-          }
-        }
-      } else {
-        audioPlayerDirective = {
-          "type": "AudioPlayer.Play",
-          "playBehavior": playBehavior,
-          "audioItem": {
-            "stream": {
-              "url": url,
-              "token": token,
-              "expectedPreviousToken": expectedPreviousToken,
-              "offsetInMilliseconds": offsetInMilliseconds
-            }
-          }
-        }
-      }
-      return self.response.response.directives.push(audioPlayerDirective);
-    },
-    stop: function () {
-      audioPlayerDirective = {
-        "type": "AudioPlayer.Stop",
-      }
-      return self.response.response.directives.push(audioPlayerDirective);
-    },
-    clearQueue: function (clearBehavior) {
-      if (0 == arguments.length) {
-        audioPlayerDirective = {
-        "type": "AudioPlayer.ClearQueue",
-        "clearBehavior": "CLEAR_ALL"
-        } 
-      } else {
-        audioPlayerDirective = {
-          "type": "AudioPlayer.ClearQueue",
-          "clearBehavior": clearBehavior
-        }
-        return self.response.response.directives.push(audioPlayerDirective);
-      }
-    }
-  }
-};
+		return this;
+	};
+	this.linkAccount = function () {
+		this.response.response.card = {
+			"type": "LinkAccount"
+		};
+		return this;
+	};
+	this.shouldEndSession = function (bool, reprompt) {
+		this.response.response.shouldEndSession = bool;
+		if (reprompt) {
+			this.reprompt(reprompt);
+		}
+		return this;
+	};
+	this.session = function (key, val) {
+		if (typeof val == "undefined") {
+			return this.response.sessionAttributes[key];
+		} else {
+			this.response.sessionAttributes[key] = val;
+		}
+		return this;
+	};
+	this.clearSession = function (key) {
+		if (typeof key == "string" && typeof this.response.sessionAttributes[key] != "undefined") {
+			delete this.response.sessionAttributes[key];
+		} else {
+			this.response.sessionAttributes = {};
+		}
+		return this;
+	};
+	this.audioPlayerPlay = function (url, token, playBehavior, offsetInMilliseconds, expectedPreviousToken) {
+		// defaults.  Must supply at least url & token, the rest are optional
+		var audioPlayerDirective = {
+			"type": "AudioPlayer.Play",
+			"playBehavior": "REPLACE_ALL",
+			"audioItem": {
+				"stream": {
+					"url": url,
+					"token": token,
+					"expectedPreviousToken": undefined,
+					"offsetInMilliseconds": 0,
+					
+				}
+			}
+		}
+		// configure with additional arguments
+		switch (arguments.length) {
+			// with playBehavior
+			case 3:
+				audioPlayerDirective.playBehavior = playBehavior;
+				break;
+			// with playBehavior & offsetInMilliseconds
+			case 4:
+				audioPlayerDirective.playBehavior = playBehavior;
+				audioPlayerDirective.audioItem.stream.offsetInMilliseconds = offsetInMilliseconds;
+				break;
+			// with playBehavior, offsetInMilliseconds, & expectedPreviousToken
+			case 5:
+				audioPlayerDirective.playBehavior = playBehavior;
+				audioPlayerDirective.audioItem.stream.offsetInMilliseconds = offsetInMilliseconds;
+				audioPlayerDirective.audioItem.stream.expectedPreviousToken = expectedPreviousToken;
+				break;
+			default:
+				break;
+		}
+		self.response.response.directives.push(audioPlayerDirective);
+		return this;
+	};
+	this.audioPlayerStop = function () {
+		var audioPlayerDirective = {
+			"type": "AudioPlayer.Stop",
+		}
+		self.response.response.directives.push(audioPlayerDirective);
+		return this;
+	};
+	this.audioPlayerClearQueue = function (clearBehavior) {
+		if (0 == arguments.length) {
+			var audioPlayerDirective = {
+				"type": "AudioPlayer.ClearQueue",
+				"clearBehavior": "CLEAR_ALL"
+			}
+		} else {
+			var audioPlayerDirective = {
+				"type": "AudioPlayer.ClearQueue",
+				"clearBehavior": clearBehavior
+			}
+			self.response.response.directives.push(audioPlayerDirective);
+		}
+		return this;
+	}
+}
 
 alexa.request = function (json) {
-  this.data = json;
-  console.log('alexa.request\'s json parameter: ', this.data);
-  this.slot = function (slotName, defaultValue) {
-    try {
-      return this.data.request.intent.slots[slotName].value;
-    } catch (e) {
-      console.error("missing intent in request: " + slotName, e);
-      return defaultValue;
-    }
-  };
-  this.type = function () {
-    try {
-      return this.data.request.type;
-    } catch (e) {
-      console.error("missing type", e);
-      return null;
-    }
-  };
-  this.sessionDetails = {
-    "new": this.data.session.new,
-    "sessionId": this.data.session.sessionId,
-    "userId": this.data.session.user.userId,
-    "accessToken": this.data.session.user.accessToken || null,
-    "attributes": this.data.session.attributes,
-    "application": this.data.session.application
-  };
-  this.userId = this.data.session.user.userId;
-  this.applicationId = this.data.session.application.applicationId;
-  this.sessionId = this.data.session.sessionId;
-  this.sessionAttributes = this.data.session.attributes;
-  this.isSessionNew = (true === this.data.session.new);
-  this.session = function (key) {
-    try {
-      return this.data.session.attributes[key];
-    } catch (e) {
-      console.error("key not found on session attributes: " + key, e);
-      return;
-    }
-  };
-  this.context = function () {
-    try {
-      return this.data.context = {
-        "System": {
-          "application": {
-            "applicationId": this.applicationId
-          },
-          "user": {
-            "userId": this.data.session.user.userId,
-            "accessToken": this.data.session.user.accessToken
-          },
-          "device": {
-            "supportedInterfaces": {
-              "AudioPlayer": {}
-            }
-          }
-        },
-        "AudioPlayer": {
-          "token": this.sessionId,
-          "offsetInMilliseconds": this.data.request.offsetInMilliseconds,
-          "playerActivity": this.data.request.playerActivity
-        }
-      };
-    } catch (e) {
-      console.error("missing context", e);
-      return null;
-    }
-  }
+	this.data = json;
+	this.slot = function (slotName, defaultValue) {
+		try {
+			return this.data.request.intent.slots[slotName].value;
+		} catch (e) {
+			console.error("missing intent in request: " + slotName, e);
+			return defaultValue;
+		}
+	};
+	this.type = function () {
+		try {
+			return this.data.request.type;
+		} catch (e) {
+			console.error("missing type", e);
+			return null;
+		}
+	};
+	this.sessionDetails = {
+		"new": this.data.session.new,
+		"sessionId": this.data.session.sessionId,
+		"userId": this.data.session.user.userId,
+		"accessToken": this.data.session.user.accessToken || null,
+		"attributes": this.data.session.attributes,
+		"application": this.data.session.application
+	};
+	this.userId = this.data.session.user.userId;
+	this.applicationId = this.data.session.application.applicationId;
+	this.sessionId = this.data.session.sessionId;
+	this.sessionAttributes = this.data.session.attributes;
+	this.isSessionNew = (true === this.data.session.new);
+	this.session = function (key) {
+		try {
+			return this.data.session.attributes[key];
+		} catch (e) {
+			console.error("key not found on session attributes: " + key, e);
+			return;
+		}
+	};
+	this.context = function () {
+		try {
+			return this.data.context = {
+				"System": {
+					"application": {
+						"applicationId": this.applicationId
+					},
+					"user": {
+						"userId": this.data.session.user.userId,
+						"accessToken": this.data.session.accessToken
+					},
+					"device": {
+						"supportedInterfaces": {
+							"AudioPlayer": {}
+						}
+					}
+				},
+				"AudioPlayer": {
+					"token": this.sessionId,
+					"offsetInMilliseconds": this.data.request.offsetInMilliseconds,
+					"playerActivity": this.data.request.playerActivity
+				}
+			};
+		} catch (e) {
+			console.error("missing context", e);
+			return null;
+		}
+	}
 };
 
 alexa.apps = {};
 
 alexa.app = function (name, endpoint) {
-  var self = this;
-  console.log('alexa.app self: ', self);
-  this.name = name;
-  this.messages = {
-    // When an intent was passed in that the application was not configured to handle
-    "NO_INTENT_FOUND": "Sorry, the application didn't know what to do with that intent",
-    // When the app was used with 'open' or 'launch' but no launch handler was defined
-    "NO_LAUNCH_FUNCTION": "Try telling the application what to do instead of opening it",
-    // When a request type was not recognized
-    "INVALID_REQUEST_TYPE": "Error: not a valid request",
-    // If some other exception happens
-    "GENERIC_ERROR": "Sorry, the application encountered an error"
-  };
+	var self = this;
+	this.name = name;
+	this.messages = {
+		// When an intent was passed in that the application was not configured to handle
+		"NO_INTENT_FOUND": "Sorry, the application didn't know what to do with that intent",
+		// When the app was used with 'open' or 'launch' but no launch handler was defined
+		"NO_LAUNCH_FUNCTION": "Try telling the application what to do instead of opening it",
+		// When a request type was not recognized
+		"INVALID_REQUEST_TYPE": "Error: not a valid request",
+		// If some other exception happens
+		"GENERIC_ERROR": "Sorry, the application encountered an error"
+	};
 
-  // Persist session variables from every request into every response?
-  this.persistentSession = true;
+	// Persist session variables from every request into every response?
+	this.persistentSession = true;
 
-  // use a minimal set of utterances or the full cartesian product?
-  this.exhaustiveUtterances = false;
+	// use a minimal set of utterances or the full cartesian product?
+	this.exhaustiveUtterances = false;
 
-  // A catch-all error handler - do nothing by default
-  this.error = null;
+	// A catch-all error handler - do nothing by default
+	this.error = null;
 
-  // pre/post hooks to be run on every request
-  this.pre = function (/*request, response, type*/) { };
-  this.post = function (/*request, response, type*/) { };
+	// pre/post hooks to be run on every request
+	this.pre = function (/*request, response, type*/) { };
+	this.post = function (/*request, response, type*/) { };
 
-  this.endpoint = endpoint;
-  // A mapping of keywords to arrays of possible values, for expansion of sample utterances
-  this.dictionary = {};
-  this.intents = {};
-  this.intent = function (intentName, schema, func) {
-    if (typeof schema == "function") {
-      func = schema;
-      schema = null;
-    }
-    self.intents[intentName] = {
-      "name": intentName,
-      "function": func
-    };
-    if (schema) {
-      self.intents[intentName].schema = schema;
-    }
-  };
-  this.launchFunc = null;
-  this.launch = function (func) {
-    self.launchFunc = func;
-  };
-  this.sessionEndedFunc = null;
-  this.sessionEnded = function (func) {
-    self.sessionEndedFunc = func;
-  };
-  this.request = function (request_json) {
-    console.log('request_json in this.request: ', request_json);
-    return new Promise(function (resolve, reject) {
-      var request = new alexa.request(request_json);
-      console.log('request in this.request\'s promise: ', request);
-      var response = new alexa.response();
-      console.log('response in this.request\'s promise: ', response);
-      var postExecuted = false;
-      // Attach Promise resolve/reject functions to the response object
-      response.send = function (exception) {
-        if (typeof self.post == "function" && !postExecuted) {
-          postExecuted = true;
-          self.post(request, response, requestType, exception);
-        }
-        if (!response.resolved) {
-          response.resolved = true;
-          resolve(response.response);
-        }
-      };
-      response.fail = function (msg, exception) {
-        if (typeof self.post == "function" && !postExecuted) {
-          postExecuted = true;
-          self.post(request, response, requestType, exception);
-        }
-        if (!response.resolved) {
-          response.resolved = true;
-          reject(msg);
-        }
-      };
-      try {
-        var key;
-        // Copy all the session attributes from the request into the response so they persist.
-        // The Alexa API doesn't think session variables should persist for the entire 
-        // duration of the session, but I do.
-        if (request.sessionAttributes && self.persistentSession) {
-          for (key in request.sessionAttributes) {
-            response.session(key, request.sessionAttributes[key]);
-          }
-        }
-        var context = request.context();
-        console.log('context in try block in this.request: ', context);
-        var requestType = request.type();
-        if (typeof self.pre == "function") {
-          self.pre(request, response, requestType);
-        }
-        if (!response.resolved) {
-          if ("IntentRequest" === requestType) {
-            var intent = request_json.request.intent.name;
-            if (typeof self.intents[intent] != "undefined" && typeof self.intents[intent]["function"] == "function") {
-              if (false !== self.intents[intent]["function"](request, response)) {
-                response.send();
-              }
-            } else {
-              throw "NO_INTENT_FOUND";
-            }
-          } else if ("LaunchRequest" === requestType) {
-            if (typeof self.launchFunc == "function") {
-              if (false !== self.launchFunc(request, response)) {
-                response.send();
-              }
-            } else {
-              throw "NO_LAUNCH_FUNCTION";
-            }
-          } else if ("SessionEndedRequest" === requestType) {
-            if (typeof self.sessionEndedFunc == "function") {
-              if (false !== self.sessionEndedFunc(request, response)) {
-                response.send();
-              }
-            }
-          } else {
-            throw "INVALID_REQUEST_TYPE";
-          }
-        }
-      } catch (e) {
-        if (typeof self.error == "function") {
-          self.error(e, request, response);
-        } else if (typeof e == "string" && self.messages[e]) {
-          response.say(self.messages[e]);
-          response.send(e);
-        }
-        if (!response.resolved) {
-          response.fail("Unhandled exception" + e.message, e);
-        }
-      }
-    });
-  };
+	this.endpoint = endpoint;
+	// A mapping of keywords to arrays of possible values, for expansion of sample utterances
+	this.dictionary = {};
+	this.intents = {};
+	this.intent = function (intentName, schema, func) {
+		if (typeof schema == "function") {
+			func = schema;
+			schema = null;
+		}
+		self.intents[intentName] = {
+			"name": intentName,
+			"function": func
+		};
+		if (schema) {
+			self.intents[intentName].schema = schema;
+		}
+	};
+	this.launchFunc = null;
+	this.launch = function (func) {
+		self.launchFunc = func;
+	};
+	this.sessionEndedFunc = null;
+	this.sessionEnded = function (func) {
+		self.sessionEndedFunc = func;
+	};
+	this.request = function (request_json) {
+		return new Promise(function (resolve, reject) {
+			var request = new alexa.request(request_json);
+			var response = new alexa.response();
+			var postExecuted = false;
+			// Attach Promise resolve/reject functions to the response object
+			response.send = function (exception) {
+				if (typeof self.post == "function" && !postExecuted) {
+					postExecuted = true;
+					self.post(request, response, requestType, exception);
+				}
+				if (!response.resolved) {
+					response.resolved = true;
+					resolve(response.response);
+				}
+			};
+			response.fail = function (msg, exception) {
+				if (typeof self.post == "function" && !postExecuted) {
+					postExecuted = true;
+					self.post(request, response, requestType, exception);
+				}
+				if (!response.resolved) {
+					response.resolved = true;
+					reject(msg);
+				}
+			};
+			try {
+				var key;
+				// Copy all the session attributes from the request into the response so they persist.
+				// The Alexa API doesn't think session variables should persist for the entire 
+				// duration of the session, but I do.
+				if (request.sessionAttributes && self.persistentSession) {
+					for (key in request.sessionAttributes) {
+						response.session(key, request.sessionAttributes[key]);
+					}
+				}
+				var context = request.context();
+				var requestType = request.type();
+				if (typeof self.pre == "function") {
+					self.pre(request, response, requestType);
+				}
+				if (!response.resolved) {
+					if ("IntentRequest" === requestType) {
+						var intent = request_json.request.intent.name;
+						if (typeof self.intents[intent] != "undefined" && typeof self.intents[intent]["function"] == "function") {
+							if (false !== self.intents[intent]["function"](request, response)) {
+								response.send();
+							}
+						} else {
+							throw "NO_INTENT_FOUND";
+						}
+					} else if ("LaunchRequest" === requestType) {
+						if (typeof self.launchFunc == "function") {
+							if (false !== self.launchFunc(request, response)) {
+								response.send();
+							}
+						} else {
+							throw "NO_LAUNCH_FUNCTION";
+						}
+					} else if ("SessionEndedRequest" === requestType) {
+						if (typeof self.sessionEndedFunc == "function") {
+							if (false !== self.sessionEndedFunc(request, response)) {
+								response.send();
+							}
+						}
+					} else {
+						throw "INVALID_REQUEST_TYPE";
+					}
+				}
+			} catch (e) {
+				if (typeof self.error == "function") {
+					self.error(e, request, response);
+				} else if (typeof e == "string" && self.messages[e]) {
+					response.say(self.messages[e]);
+					response.send(e);
+				}
+				if (!response.resolved) {
+					response.fail("Unhandled exception" + e.message, e);
+				}
+			}
+		});
+	};
 
-  // Extract the schema and generate a schema JSON object
-  this.schema = function () {
-    var schema = {
-      "intents": []
-    }, intentName, intent, key;
-    for (intentName in self.intents) {
-      intent = self.intents[intentName];
-      var intentSchema = {
-        "intent": intent.name,
-        "slots": []
-      };
-      if (intent.schema) {
-        if (intent.schema.slots) {
-          for (key in intent.schema.slots) {
-            intentSchema.slots.push({
-              "name": key,
-              "type": intent.schema.slots[key]
-            });
-          }
-        }
-      }
-      schema.intents.push(intentSchema);
-    }
-    return JSON.stringify(schema, null, 3);
-  };
+	// Extract the schema and generate a schema JSON object
+	this.schema = function () {
+		var schema = {
+			"intents": []
+		}, intentName, intent, key;
+		for (intentName in self.intents) {
+			intent = self.intents[intentName];
+			var intentSchema = {
+				"intent": intent.name,
+				"slots": []
+			};
+			if (intent.schema) {
+				if (intent.schema.slots) {
+					for (key in intent.schema.slots) {
+						intentSchema.slots.push({
+							"name": key,
+							"type": intent.schema.slots[key]
+						});
+					}
+				}
+			}
+			schema.intents.push(intentSchema);
+		}
+		return JSON.stringify(schema, null, 3);
+	};
 
-  // Generate a list of sample utterances
-  this.utterances = function () {
-    var intentName,
-      intent,
-      out = "";
-    for (intentName in self.intents) {
-      intent = self.intents[intentName];
-      if (intent.schema && intent.schema.utterances) {
-        intent.schema.utterances.forEach(function (sample) {
-          var list = AlexaUtterances(sample,
-            intent.schema.slots,
-            self.dictionary,
-            self.exhaustiveUtterances);
-          list.forEach(function (utterance) {
-            out += intent.name + "\t" + (utterance.replace(/\s+/g, " ")).trim() + "\n";
-          });
-        });
-      }
-    }
-    return out;
-  };
+	// Generate a list of sample utterances
+	this.utterances = function () {
+		var intentName,
+			intent,
+			out = "";
+		for (intentName in self.intents) {
+			intent = self.intents[intentName];
+			if (intent.schema && intent.schema.utterances) {
+				intent.schema.utterances.forEach(function (sample) {
+					var list = AlexaUtterances(sample,
+						intent.schema.slots,
+						self.dictionary,
+						self.exhaustiveUtterances);
+					list.forEach(function (utterance) {
+						out += intent.name + "\t" + (utterance.replace(/\s+/g, " ")).trim() + "\n";
+					});
+				});
+			}
+		}
+		return out;
+	};
 
-  // A built-in handler for AWS Lambda
-  this.handler = function (event, context) {
-    self.request(event)
-      .then(function (response) {
-        context.succeed(response);
-      })
-      .catch(function (response) {
-        context.fail(response);
-      });
-  };
+	// A built-in handler for AWS Lambda
+	this.handler = function (event, context) {
+		self.request(event)
+			.then(function (response) {
+				context.succeed(response);
+			})
+			.catch(function (response) {
+				context.fail(response);
+			});
+	};
 
-  // For backwards compatibility
-  this.lambda = function () {
-    return self.handler;
-  };
+	// For backwards compatibility
+	this.lambda = function () {
+		return self.handler;
+	};
 
-  // A utility method to bootstrap alexa endpoints into express automatically
-  this.express = function (express, path, enableDebug) {
-    var endpoint = (path || "/") + (self.endpoint || self.name);
-    express.post(endpoint, function (req, res) {
-      self.request(req.body).then(function (response) {
-        res.json(response);
-      }, function () {
-        res.status(500).send("Server Error");
-      });
-    });
-    if (typeof enableDebug != "boolean") {
-      enableDebug = true;
-    }
-    if (enableDebug) {
-      express.get(endpoint, function (req, res) {
-        res.render("test", {
-          "json": self,
-          "schema": self.schema(),
-          "utterances": self.utterances()
-        });
-      });
-    }
-  };
+	// A utility method to bootstrap alexa endpoints into express automatically
+	this.express = function (express, path, enableDebug) {
+		var endpoint = (path || "/") + (self.endpoint || self.name);
+		express.post(endpoint, function (req, res) {
+			self.request(req.body).then(function (response) {
+				res.json(response);
+			}, function () {
+				res.status(500).send("Server Error");
+			});
+		});
+		if (typeof enableDebug != "boolean") {
+			enableDebug = true;
+		}
+		if (enableDebug) {
+			express.get(endpoint, function (req, res) {
+				res.render("test", {
+					"json": self,
+					"schema": self.schema(),
+					"utterances": self.utterances()
+				});
+			});
+		}
+	};
 
-  // Add the app to the global list of named apps
-  if (name) {
-    alexa.apps[name] = self;
-  }
-  console.log('this! :', this);
-  return this;
+	// Add the app to the global list of named apps
+	if (name) {
+		alexa.apps[name] = self;
+	}
+	return this;
 };
 
 module.exports = alexa;

--- a/index.js
+++ b/index.js
@@ -172,11 +172,12 @@ alexa.response = function () {
 	};
 	this.audioPlayerClearQueue = function (clearBehavior) {
 		var audioPlayerDirective;
-		if (0 == arguments.length) {
+		if (arguments.length === 0) {
 			audioPlayerDirective = {
 				"type": "AudioPlayer.ClearQueue",
 				"clearBehavior": "CLEAR_ALL"
 			};
+			self.response.response.directives.push(audioPlayerDirective);
 		} else {
 			audioPlayerDirective = {
 				"type": "AudioPlayer.ClearQueue",
@@ -312,7 +313,6 @@ alexa.app = function (name, endpoint) {
 		self.sessionEndedFunc = func;
 	};
 	this.request = function (request_json) {
-		// console.log('request_json --->', request_json);
 		return new Promise(function (resolve, reject) {
 			var request = new alexa.request(request_json);
 			var response = new alexa.response();

--- a/index.js
+++ b/index.js
@@ -136,11 +136,10 @@ alexa.response = function () {
 					"url": url,
 					"token": token,
 					"expectedPreviousToken": undefined,
-					"offsetInMilliseconds": 0,
-					
+					"offsetInMilliseconds": 0
 				}
 			}
-		}
+		};
 		// configure with additional arguments
 		switch (arguments.length) {
 			// with playBehavior
@@ -167,25 +166,26 @@ alexa.response = function () {
 	this.audioPlayerStop = function () {
 		var audioPlayerDirective = {
 			"type": "AudioPlayer.Stop",
-		}
+		};
 		self.response.response.directives.push(audioPlayerDirective);
 		return this;
 	};
 	this.audioPlayerClearQueue = function (clearBehavior) {
+		var audioPlayerDirective;
 		if (0 == arguments.length) {
-			var audioPlayerDirective = {
+			audioPlayerDirective = {
 				"type": "AudioPlayer.ClearQueue",
 				"clearBehavior": "CLEAR_ALL"
-			}
+			};
 		} else {
-			var audioPlayerDirective = {
+			audioPlayerDirective = {
 				"type": "AudioPlayer.ClearQueue",
 				"clearBehavior": clearBehavior
-			}
+			};
 			self.response.response.directives.push(audioPlayerDirective);
 		}
 		return this;
-	}
+	};
 }
 
 alexa.request = function (json) {
@@ -254,7 +254,7 @@ alexa.request = function (json) {
 			console.error("missing context", e);
 			return null;
 		}
-	}
+	};
 };
 
 alexa.apps = {};
@@ -347,7 +347,6 @@ alexa.app = function (name, endpoint) {
 						response.session(key, request.sessionAttributes[key]);
 					}
 				}
-				var context = request.context();
 				var requestType = request.type();
 				if (typeof self.pre == "function") {
 					self.pre(request, response, requestType);

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ alexa.response = function () {
 	};
 	this.audioPlayerStop = function () {
 		var audioPlayerDirective = {
-			"type": "AudioPlayer.Stop",
+			"type": "AudioPlayer.Stop"
 		};
 		self.response.response.directives.push(audioPlayerDirective);
 		return this;
@@ -186,7 +186,7 @@ alexa.response = function () {
 		}
 		return this;
 	};
-}
+};
 
 alexa.request = function (json) {
 	this.data = json;

--- a/test/fixtures/intent_audioplayer.json
+++ b/test/fixtures/intent_audioplayer.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.0",
+    "session": {
+        "new": false,
+        "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+        "application": {
+            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+        },
+        "attributes": {},
+        "user": {
+            "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+        }
+    },
+    "request": {
+        "type": "IntentRequest",
+        "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+        "timestamp": "2015-05-13T12:34:56Z",
+        "intent": {
+            "name": "audioPlayerIntent",
+            "slots": {}
+        },
+        "context": {
+            "application": {
+                "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00fuck"
+            },
+            "user": {
+                "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+                "accessToken": "sample.accessToken"
+            },
+            "device": {
+                "supportedInterfaces": {
+                    "AudioPlayer": {}
+                }
+            }
+        },
+        "AudioPlayer": {
+            "token": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+            "offsetInMilliseconds": 0,
+            "playerActivity": "PLAYING"
+        }
+    }
+}

--- a/test/fixtures/intent_request_airport_info.json
+++ b/test/fixtures/intent_request_airport_info.json
@@ -1,23 +1,23 @@
 {
-  "version": "1.0",
-  "session": {
-      "new": false,
-      "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
-      "application": {
+    "version": "1.0",
+    "session": {
+        "new": false,
+        "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+        "application": {
             "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
-          },
-      "attributes": {},
-      "user": {
+        },
+        "attributes": {},
+        "user": {
             "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
-          }
+        }
     },
-  "request": {
-      "type": "IntentRequest",
-      "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
-      "timestamp": "2015-05-13T12:34:56Z",
-      "intent": {
+    "request": {
+        "type": "IntentRequest",
+        "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+        "timestamp": "2015-05-13T12:34:56Z",
+        "intent": {
             "name": "airportInfoIntent",
             "slots": {}
-          }
+        }
     }
 }

--- a/test/test_alexa_app_audioplayer.js
+++ b/test/test_alexa_app_audioplayer.js
@@ -8,33 +8,171 @@ var expect = chai.expect;
 chai.config.includeStack = true;
 
 
-describe("Alexa", function() {
-    var Alexa = require("../index");
-    describe("app", function() {
-        var app = new Alexa.app("myapp");
-        context("with an audioPlayer intent", function() {
-            describe("request", function() {
-                var mockRequest = mockHelper.load("intent_audioplayer.json");
-                it("includes the context object", function() {
-                    return expect(mockRequest.request).to.have.property("context");
-                });
-                it("request includes AudioPlayer object", function() {
-                    return expect(mockRequest.request).to.have.property("AudioPlayer");
-                });
-            });
-            describe("response", function() {
-                context("alexa directive response", function() {
-                    it("responds with alexa response AudioPlayer directive", function() {
-                        var mockRequest = mockHelper.load("intent_audioplayer.json"),
-                            subject = app.request(mockRequest);
-                        subject = subject.then(function(response) {
-                            console.log('response --->', response);
-                            return response.response.directives;
-                        });
-                        return expect(subject).to.eventually.be.an("array");
-                    });
-                });
-            });
+describe("Alexa", function () {
+  var Alexa = require("../index");
+  describe("app", function () {
+    var app = new Alexa.app("myapp");
+    describe("request", function () {
+      context("with an audioPlayer intent", function () {
+        var mockRequest = mockHelper.load("intent_audioplayer.json");
+        it("includes the context object", function () {
+          return expect(mockRequest.request).to.have.property("context");
         });
+        it("request includes AudioPlayer object", function () {
+          return expect(mockRequest.request).to.have.property("AudioPlayer");
+        });
+      });
+      describe("response", function () {
+        context("alexa directive response", function () {
+          var mockRequest = mockHelper.load("intent_audioplayer.json"),
+            Url = "someurl.com",
+            token = "some_token",
+            playBehavior = "ENQUEUE",
+            offsetInMilliseconds = 1000,
+            expectedPreviousToken = "some_previous_token";
+          it("contains AudioPlayer directive array property", function () {
+            var intentHandler = function (req, res) {
+              res.audioPlayerPlay(Url, token);
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest);
+            subject = subject.then(function (response) {
+              return response.response.directives;
+            });
+            return expect(subject).to.eventually.be.an("array");
+          });
+          it("audioPlayerPlay directive can take url & token", function () {
+            var intentHandler = function (req, res) {
+              res.audioPlayerPlay(Url, token);
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.Play',
+              playBehavior: 'REPLACE_ALL',
+              audioItem: {
+                stream: {
+                  url: 'someurl.com',
+                  token: 'some_token',
+                  expectedPreviousToken: undefined,
+                  offsetInMilliseconds: 0
+                }
+              }
+            });
+          });
+          it("audioPlayerPlay directive can take url, token, & playBehavior ", function () {
+            var intentHandler = function (req, res) {
+              res.audioPlayerPlay(Url, token, playBehavior);
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.Play',
+              playBehavior: 'ENQUEUE',
+              audioItem: {
+                stream: {
+                  url: 'someurl.com',
+                  token: 'some_token',
+                  expectedPreviousToken: undefined,
+                  offsetInMilliseconds: 0
+                }
+              }
+            });
+          });
+          it("audioPlayerPlay directive can take url, token, playBehavior, & offsetInMilliseconds", function () {
+            var intentHandler = function (req, res) {
+              res.audioPlayerPlay(Url, token, playBehavior, offsetInMilliseconds);
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.Play',
+              playBehavior: 'ENQUEUE',
+              audioItem: {
+                stream: {
+                  url: 'someurl.com',
+                  token: 'some_token',
+                  expectedPreviousToken: undefined,
+                  offsetInMilliseconds: 1000
+                }
+              }
+            });
+          });
+          it("audioPlayerPlay directive can take url, token, playBehavior, offsetInMilliseconds, & expectedPreviousToken", function () {
+            var intentHandler = function (req, res) {
+              res.audioPlayerPlay(Url, token, playBehavior, offsetInMilliseconds, expectedPreviousToken);
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.Play',
+              playBehavior: 'ENQUEUE',
+              audioItem: {
+                stream: {
+                  url: 'someurl.com',
+                  token: 'some_token',
+                  expectedPreviousToken: "some_previous_token",
+                  offsetInMilliseconds: 1000
+                }
+              }
+            });
+          });
+          it("audioPlayerStop directive", function() {
+            var intentHandler = function(req, res) {
+              res.audioPlayerStop();
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.Stop'
+            });
+          });
+          it("audioPlayerClearQueue w/o clearBehavior arg", function() {
+            var intentHandler = function(req, res) {
+              res.audioPlayerClearQueue();
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.ClearQueue',
+              clearBehavior: "CLEAR_ALL"
+            });
+          });
+          it("audioPlayerClearQueue w/ clearBehavior arg", function() {
+            var intentHandler = function(req, res) {
+              res.audioPlayerClearQueue("CLEAR_ENQUEUED");
+              return true;
+            };
+            app.intent("audioPlayerIntent", {}, intentHandler);
+            var subject = app.request(mockRequest).then(function (response) {
+              return response.response.directives[0];
+            });
+            return expect(subject).to.eventually.become({
+              type: 'AudioPlayer.ClearQueue',
+              clearBehavior: "CLEAR_ENQUEUED"
+            });
+          });
+        });
+      });
     });
+  });
 });

--- a/test/test_alexa_app_audioplayer.js
+++ b/test/test_alexa_app_audioplayer.js
@@ -1,0 +1,40 @@
+/*jshint expr: true*/
+"use strict";
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+var mockHelper = require("./helpers/mock_helper");
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+chai.config.includeStack = true;
+
+
+describe("Alexa", function() {
+    var Alexa = require("../index");
+    describe("app", function() {
+        var app = new Alexa.app("myapp");
+        context("with an audioPlayer intent", function() {
+            describe("request", function() {
+                var mockRequest = mockHelper.load("intent_audioplayer.json");
+                it("includes the context object", function() {
+                    return expect(mockRequest.request).to.have.property("context");
+                });
+                it("request includes AudioPlayer object", function() {
+                    return expect(mockRequest.request).to.have.property("AudioPlayer");
+                });
+            });
+            describe("response", function() {
+                context("alexa directive response", function() {
+                    it("responds with alexa response AudioPlayer directive", function() {
+                        var mockRequest = mockHelper.load("intent_audioplayer.json"),
+                            subject = app.request(mockRequest);
+                        subject = subject.then(function(response) {
+                            console.log('response --->', response);
+                            return response.response.directives;
+                        });
+                        return expect(subject).to.eventually.be.an("array");
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added Audioplayer functionality to the alexa-app library.

Simply write `response.audioPlayerPlay(url, token, playBehavior, offsetInMilliseconds, expectedPreviousToken)` and you can play long form audio URL requests with a given url and token.  `playBehavior` defaults to `"ENQUEUE_ALL"`, and `offsetInMilliseconds` defaults to 0, and `expectedPreviousToken` defaults to `undefined`.

Also, added is `response.audioPlayerStop()` and `response.audioPlayerClearQueue(clearBehavior)` where `clearBehavior` defaults to `"CLEAR_ALL"` .

The request's `context` object is required in long form audio requests since the session object is not included once the player begins playing, but is copied from the request's `session` object.