### PR TITLE
Fix "Cannot read property 'new' of undefined" init error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#76](https://github.com/matt-kruse/alexa-app/pull/76): `response.clear()` now sets the default `outputSpeech` to SSML - [@rickwargo](https://github.com/rickwargo).
 * [#90](https://github.com/matt-kruse/alexa-app/pull/90): Added [Danger](http://danger.systems), PR linter - [@dblock](https://github.com/dblock).
+* [#91](https://github.com/matt-kruse/alexa-app/pull/91): Fixed "Cannot read property 'new' of undefined" init error - [@fremail](https://github.com/fremail).
 * Your contribution here.
 
 ### 2.3.4 (May 23, 2016)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ String request.type()
 // return the value passed in for a given slot name
 String request.slot("slotName")
 
+// check if you can use session (read or write)
+Boolean request.hasSession()
+
 // return the value of a session variable
 String request.session("attributeName")
 
@@ -95,6 +98,9 @@ response.linkAccount()
 // tell Alexa whether the user's session is over; sessions end by default
 // you can optionally pass a reprompt message
 response.shouldEndSession(boolean end [, String reprompt] )
+
+// check if you can use session (read or write)
+Boolean response.hasSession()
 
 // set a session variable
 // by defailt, Alexa only persists session variables to the next request

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,45 @@
+# Upgrading Alexa-app
+
+### Upgrading to >= 2.3.5
+
+#### Changed session interface
+
+These methods and properties marked as deprecated:
+* `request.sessionDetails`
+* `request.sessionId`
+* `request.sessionAttributes`
+* `request.isSessionNew`
+* `request.session()`
+* `response.session()`
+* `response.clearSession()`
+
+Please use the `session` object from `request.getSession()` instead:
+
+```javascript
+// check if the request has session
+if (request.hasSession()) {
+  // get session object
+  var session = request.getSession();
+  // check if the session is new
+  session.isNew();
+  // set a session variable
+  session.set("foo", "bar");
+  // get a session variable
+  session.get("foo");
+  // delete one session variable
+  session.clear("foo");
+  // or clear all session variables
+  session.clear();
+  // get sessionId
+  session.sessionId;
+  // get session details
+  session.details;
+  // get session attributes (object of variables)
+  session.attributes;
+}
+```
+
+You can easily use the session, but first you need to check if `request` has session: `Boolean request.hasSession()`. Otherwise the session properties will be empty and the session functions will throw "NO_SESSION" exception.
+
+See [#91](https://github.com/matt-kruse/alexa-app/pull/91) for more information.
+

--- a/index.js
+++ b/index.js
@@ -145,6 +145,14 @@ alexa.request = function(json) {
       return null;
     }
   };
+  // session is not included for AudioPlayer or PlaybackController requests
+  if (!this.data.session) {
+    this.data.session = {
+      application: this.data.context.System.application,
+      user: this.data.context.System.user,
+      device: this.data.context.System.device
+    };
+  }
   this.sessionDetails = {
     "new": this.data.session.new,
     "sessionId": this.data.session.sessionId,

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ alexa.request = function(json) {
   // @deprecated
   this.sessionAttributes = this.getSession().attributes;
   // @deprecated
-  this.isSessionNew = this.getSession().isNew();
+  this.isSessionNew = this.hasSession() ? this.getSession().isNew() : false;
   // @deprecated
   this.session = function(key) {
     return this.getSession().get(key);

--- a/test/fixtures/audio_player_event_request.json
+++ b/test/fixtures/audio_player_event_request.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "request": {
+    "type": "AudioPlayer.PlaybackFinished",
+    "requestId": "amzn1.echo-api.request.9cdaa4db-f20e-4c58-8d01-c75322d6c423",
+    "timestamp": "2015-05-13T12:34:56Z"
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
+  }
+}

--- a/test/fixtures/intent_request_airport_info.json
+++ b/test/fixtures/intent_request_airport_info.json
@@ -19,5 +19,15 @@
       "name": "airportInfoIntent",
       "slots": {}
     }
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
   }
 }

--- a/test/fixtures/intent_request_launch.json
+++ b/test/fixtures/intent_request_launch.json
@@ -15,5 +15,15 @@
     "type": "LaunchRequest",
     "requestId": "amzn1.echo-api.request.9cdaa4db-f20e-4c58-8d01-c75322d6c423",
     "timestamp": "2015-05-13T12:34:56Z"
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
   }
 }

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -162,5 +162,71 @@ describe("Alexa", function() {
       });
     });
 
+    describe("#request", function() {
+      var mockRequest = mockHelper.load("audio_player_event_request.json");
+      context("request without session", function() {
+        var app = new Alexa.app("myapp");
+        app.pre = function(req, res, type) {
+          if (req.hasSession()) {
+            // unreachable code, because the request doesn't have session
+            req.getSession().set("foo", "bar");
+          }
+        };
+
+        it("responds with an empty session object", function() {
+          var subject = app.request(mockRequest).then(function(response) {
+            return response.sessionAttributes;
+          });
+          return Promise.all([
+            expect(subject).to.eventually.become({})
+          ]);
+        });
+
+      });
+    });
+
+    describe("#request", function() {
+      var mockRequest = mockHelper.load("audio_player_event_request.json");
+      context("request without session", function() {
+        context("trying to get session variable", function() {
+          var app = new Alexa.app("myapp");
+          app.pre = function(req, res, type) {
+            req.getSession().get("foo");
+          };
+          describe("outputSpeech", function() {
+            var subject = app.request(mockRequest).then(function(response) {
+              return response.response.outputSpeech;
+            });
+            it("responds with NO_SESSION message", function() {
+              return expect(subject).to.eventually.become({
+                ssml: "<speak>" + app.messages.NO_SESSION + "</speak>",
+                type: "SSML"
+              });
+            });
+          });
+
+        });
+
+        context("trying to set session variable", function() {
+          var app = new Alexa.app("myapp");
+          app.pre = function(req, res, type) {
+            req.getSession().set("foo", "bar");
+          };
+          describe("outputSpeech", function() {
+            var subject = app.request(mockRequest).then(function(response) {
+              return response.response.outputSpeech;
+            });
+            it("responds with NO_SESSION message", function() {
+              return expect(subject).to.eventually.become({
+                ssml: "<speak>" + app.messages.NO_SESSION + "</speak>",
+                type: "SSML"
+              });
+            });
+          });
+
+        });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
The error is caused on getting `AudioPlayer` events. I got for these events: `AudioPlayer.PlaybackStarted`, `AudioPlayer.PlaybackNearlyFinished` and `AudioPlayer.PlaybackFinished`.

```
{
    "errorMessage": "Cannot read property 'new' of undefined",
    "errorType": "TypeError",
    "stackTrace": [
        "new alexa.request (/var/task/node_modules/alexa-app/index.js:219:27)",
        "/var/task/node_modules/alexa-app/index.js:317:18",
        "tryCatcher (/var/task/node_modules/alexa-app/node_modules/bluebird/js/main/util.js:26:23)",
        "Promise._resolveFromResolver (/var/task/node_modules/alexa-app/node_modules/bluebird/js/main/promise.js:483:31)",
        "new Promise (/var/task/node_modules/alexa-app/node_modules/bluebird/js/main/promise.js:71:37)",
        "request (/var/task/node_modules/alexa-app/index.js:316:10)",
        "handler (/var/task/node_modules/alexa-app/index.js:448:8)"
    ]
}
```

As Amazon [wrote](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#request-body-parameters):
> The session object is included for all standard requests, but it is not included for AudioPlayer or PlaybackController requests.

Additional info regarding to this error you can find in PR #88 and Issue #78 