### PR TITLE
Fix initialization alexa-app on a request without context

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,36 +183,6 @@ alexa.request = function(json) {
       return null;
     }
   };
-  this.userId = this.data.context.System.user.userId;
-  this.applicationId = this.data.context.System.application.applicationId;
-  this.context = function () {
-    try {
-      return this.data.request.context = {
-        "System": {
-          "application": {
-            "applicationId": this.applicationId
-          },
-          "user": {
-            "userId": this.data.session.user.userId,
-            "accessToken": this.data.session.accessToken
-          },
-          "device": {
-            "supportedInterfaces": {
-              "AudioPlayer": {}
-            }
-          }
-        },
-        "AudioPlayer": {
-          "token": this.sessionId,
-          "offsetInMilliseconds": this.data.request.offsetInMilliseconds,
-          "playerActivity": this.data.request.playerActivity
-        }
-      };
-    } catch (e) {
-      console.error("missing context", e);
-      return null;
-    }
-  };
 
   var session = new alexa.session(json.session);
   this.hasSession = function() {
@@ -220,6 +190,42 @@ alexa.request = function(json) {
   };
   this.getSession = function() {
     return session;
+  };
+
+  this.userId = null;
+  this.applicationId = null;
+  var context = null;
+  if (json.context || json.request.context) {
+    context = json.context || json.request.context;
+    this.userId = context.System.user.userId;
+    this.applicationId = context.System.application.applicationId;
+  } else if (this.hasSession()) {
+    this.userId = session.details.userId;
+    this.applicationId = session.details.application.applicationId;
+    context = {
+      "System": {
+        "application": {
+          "applicationId": this.applicationId
+        },
+        "user": {
+          "userId": this.userId,
+          "accessToken": session.details.accessToken
+        },
+        "device": {
+          "supportedInterfaces": {
+            "AudioPlayer": {}
+          }
+        }
+      },
+      "AudioPlayer": {
+        "token": null,
+        "offsetInMilliseconds": null,
+        "playerActivity": null
+      }
+    };
+  }
+  this.context = function() {
+    return this.data.context = this.data.request.context = context;
   };
 
   // legacy code below

--- a/test/fixtures/intent_audioplayer.json
+++ b/test/fixtures/intent_audioplayer.json
@@ -1,52 +1,44 @@
 {
-    "version": "1.0",
-    "session": {
-        "new": false,
-        "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
-        "application": {
-            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
-        },
-        "attributes": {},
-        "user": {
-            "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
-        }
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
     },
-    "request": {
-        "type": "IntentRequest",
-        "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
-        "timestamp": "2015-05-13T12:34:56Z",
-        "intent": {
-            "name": "audioPlayerIntent",
-            "slots": {}
-        },
-        "context": {
-            "application": {
-                "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00fuck"
-            },
-            "user": {
-                "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
-                "accessToken": "sample.accessToken"
-            },
-            "device": {
-                "supportedInterfaces": {
-                    "AudioPlayer": {}
-                }
-            }
-        },
-        "AudioPlayer": {
-            "token": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
-            "offsetInMilliseconds": 0,
-            "playerActivity": "PLAYING"
-        }
-    },
-    "context": {
-        "System": {
-            "user": {
-                "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
-            },
-            "application": {
-                "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
-            }
-        }
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
     }
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "audioPlayerIntent",
+      "slots": {}
+    }
+  },
+  "context": {
+    "System": {
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00fuck"
+      },
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+        "accessToken": "sample.accessToken"
+      },
+      "device": {
+        "supportedInterfaces": {
+          "AudioPlayer": {}
+        }
+      }
+    },
+    "AudioPlayer": {
+      "token": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+      "offsetInMilliseconds": 0,
+      "playerActivity": "PLAYING"
+    }
+  }
 }

--- a/test/fixtures/intent_request_airport_info.json
+++ b/test/fixtures/intent_request_airport_info.json
@@ -19,15 +19,5 @@
       "name": "airportInfoIntent",
       "slots": {}
     }
-  },
-  "context": {
-    "System": {
-      "user": {
-        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
-      },
-      "application": {
-        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
-      }
-    }
   }
 }

--- a/test/fixtures/intent_request_launch.json
+++ b/test/fixtures/intent_request_launch.json
@@ -15,15 +15,5 @@
     "type": "LaunchRequest",
     "requestId": "amzn1.echo-api.request.9cdaa4db-f20e-4c58-8d01-c75322d6c423",
     "timestamp": "2015-05-13T12:34:56Z"
-  },
-  "context": {
-    "System": {
-      "user": {
-        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
-      },
-      "application": {
-        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
-      }
-    }
   }
 }

--- a/test/fixtures/pure_intent_request.json
+++ b/test/fixtures/pure_intent_request.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "pureIntent",
+      "slots": {}
+    }
+  }
+}

--- a/test/test_alexa_app_audioplayer.js
+++ b/test/test_alexa_app_audioplayer.js
@@ -16,10 +16,10 @@ describe("Alexa", function () {
       context("with an audioPlayer intent", function () {
         var mockRequest = mockHelper.load("intent_audioplayer.json");
         it("includes the context object", function () {
-          return expect(mockRequest.request).to.have.property("context");
+          return expect(mockRequest).to.have.property("context");
         });
-        it("request includes AudioPlayer object", function () {
-          return expect(mockRequest.request).to.have.property("AudioPlayer");
+        it("request context includes AudioPlayer object", function () {
+          return expect(mockRequest.context).to.have.property("AudioPlayer");
         });
       });
       describe("response", function () {

--- a/test/test_alexa_app_context.js
+++ b/test/test_alexa_app_context.js
@@ -1,0 +1,68 @@
+/*jshint expr: true*/
+"use strict";
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+var mockHelper = require("./helpers/mock_helper");
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+chai.config.includeStack = true;
+
+describe("Alexa", function() {
+  var Alexa = require("../index");
+  describe("app", function() {
+    describe("request", function() {
+      var app = new Alexa.app("myapp");
+      var requestContext, appId;
+      app.pre = function(request, response) {
+        requestContext = request.context();
+        appId = request.applicationId;
+      };
+
+      describe("with context", function() {
+        var mockRequest = mockHelper.load("audio_player_event_request.json");
+        it("request json contains context, but without session", function() {
+          return expect(mockRequest).to.have.property("context") && expect(mockRequest).to.not.have.property("session");
+        });
+        it("app request context is an object", function() {
+          app.request(mockRequest);
+          return expect(requestContext).to.be.an("object");
+        });
+        it("request.applicationId is not null", function() {
+          app.request(mockRequest);
+          return expect(appId).to.not.be.null;
+        });
+      });
+
+      describe("without context but with session", function() {
+        var mockRequest = mockHelper.load("intent_request_airport_info.json");
+        it("request json contains session, but without context object", function() {
+          return expect(mockRequest).to.have.property("session") && expect(mockRequest).to.not.have.property("context");
+        });
+        it("app request context exists", function() {
+          app.request(mockRequest);
+          return expect(requestContext).to.be.an("object");
+        });
+        it("request.applicationId is not null", function() {
+          app.request(mockRequest);
+          return expect(appId).to.not.be.null;
+        });
+      });
+
+      describe("without context and session", function() {
+        var mockRequest = mockHelper.load("pure_intent_request.json");
+        it("request json doesn't have context object and session object", function() {
+          return expect(mockRequest).to.not.have.property("context") && expect(mockRequest).to.not.have.property("session");
+        });
+        it("app request context is null", function() {
+          app.request(mockRequest);
+          return expect(requestContext).to.be.null;
+        });
+        it("request.applicationId is null", function() {
+          app.request(mockRequest);
+          return expect(appId).to.be.null;
+        });
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
Fixes #96 

Try to get `userId`, `applicationId` and `context` object from `json.context` or `json.request.context`. 
In case of absense `context` in the request json try to get data from `json.session`.
If the request is w/o session, `userId`, `applicationId` and `context` will be null.

Also I removed `context` object from test requests which I had added before.