### PR TITLE
Context should not be secondary to session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#90](https://github.com/matt-kruse/alexa-app/pull/90): Added [Danger](http://danger.systems), PR linter - [@dblock](https://github.com/dblock).
 * [#91](https://github.com/matt-kruse/alexa-app/pull/91): Fixed "Cannot read property 'new' of undefined" init error - [@fremail](https://github.com/fremail).
 * [#88](https://github.com/matt-kruse/alexa-app/pull/88), [#92](https://github.com/matt-kruse/alexa-app/pull/92): AudioPlayer functionality - [@wschaeferiii](https://github.com/wschaeferiii) and [@fremail](https://github.com/fremail).
+* [#101](https://github.com/matt-kruse/alexa-app/pull/101): Expect request `context` to always be present and not modify that data. [@trayburn](https://github.com/trayburn)
 * Your contribution here.
 
 ### 2.3.4 (May 23, 2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [#90](https://github.com/matt-kruse/alexa-app/pull/90): Added [Danger](http://danger.systems), PR linter - [@dblock](https://github.com/dblock).
 * [#91](https://github.com/matt-kruse/alexa-app/pull/91): Fixed "Cannot read property 'new' of undefined" init error - [@fremail](https://github.com/fremail).
 * [#88](https://github.com/matt-kruse/alexa-app/pull/88), [#92](https://github.com/matt-kruse/alexa-app/pull/92): AudioPlayer functionality - [@wschaeferiii](https://github.com/wschaeferiii) and [@fremail](https://github.com/fremail).
-* [#101](https://github.com/matt-kruse/alexa-app/pull/101): Expect request `context` to always be present and not modify that data. [@trayburn](https://github.com/trayburn)
+* [#101](https://github.com/matt-kruse/alexa-app/pull/101): Added `request.context` - [@trayburn](https://github.com/trayburn).
 * Your contribution here.
 
 ### 2.3.4 (May 23, 2016)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Boolean request.hasSession()
 // return the session object
 Session request.getSession()
 
+// return the request context
+request.context
+
 // the raw request JSON object
 request.data
 ```

--- a/index.js
+++ b/index.js
@@ -183,9 +183,16 @@ alexa.request = function(json) {
       return null;
     }
   };
-  this.userId = this.data.context.System.user.userId;
-  this.applicationId = this.data.context.System.application.applicationId;
-  this.context = this.data.context;
+
+  this.userId = null;
+  this.applicationId = null;
+  this.context = null;
+
+  if (this.data.context) {
+    this.userId = this.data.context.System.user.userId;
+    this.applicationId = this.data.context.System.application.applicationId;
+    this.context = this.data.context;
+  }
 
   var session = new alexa.session(json.session);
   this.hasSession = function() {

--- a/index.js
+++ b/index.js
@@ -185,10 +185,7 @@ alexa.request = function(json) {
   };
   this.userId = this.data.context.System.user.userId;
   this.applicationId = this.data.context.System.application.applicationId;
-  
-  this.context = function () {
-    return this.data.request.context;
-  };
+  this.context = this.data.context;
 
   var session = new alexa.session(json.session);
   this.hasSession = function() {

--- a/index.js
+++ b/index.js
@@ -185,33 +185,9 @@ alexa.request = function(json) {
   };
   this.userId = this.data.context.System.user.userId;
   this.applicationId = this.data.context.System.application.applicationId;
+  
   this.context = function () {
-    try {
-      return this.data.request.context = {
-        "System": {
-          "application": {
-            "applicationId": this.applicationId
-          },
-          "user": {
-            "userId": this.data.session.user.userId,
-            "accessToken": this.data.session.accessToken
-          },
-          "device": {
-            "supportedInterfaces": {
-              "AudioPlayer": {}
-            }
-          }
-        },
-        "AudioPlayer": {
-          "token": this.sessionId,
-          "offsetInMilliseconds": this.data.request.offsetInMilliseconds,
-          "playerActivity": this.data.request.playerActivity
-        }
-      };
-    } catch (e) {
-      console.error("missing context", e);
-      return null;
-    }
+    return this.data.request.context;
   };
 
   var session = new alexa.session(json.session);

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -26,6 +26,15 @@ describe("Alexa", function() {
           return true;
         };
         app.intent("airportInfoIntent", {}, intentHandler);
+
+        it("reponds with expected context applicationId", function() {
+          return app.request(mockRequest).then((response) => {
+            expect(reqObject.context).to
+              .have.deep.property("System.application.applicationId", "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe");
+          });
+        });
+
+
         it("responds with a session object", function() {
           var subject = app.request(mockRequest).then(function(response) {
             return response.sessionAttributes;


### PR DESCRIPTION
According to Amazon's documentation, `context` is sent on every request (including AudioPlayer events) but `session` is only sent on standard requests.  As such we should not be clobbering the submitted context with information from context.  This is particularly dangerous when you also are clobbering `token` with `sessionId`, which makes it impossible to track which stream is currently playing on the client.

Citation:
https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#context-object
https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#session-object
